### PR TITLE
allow wrollup to work with Windows path separators 

### DIFF
--- a/index.js
+++ b/index.js
@@ -57,7 +57,7 @@ var configPath = path.resolve(argv['c'] || argv['config'] || 'rollup.config.js')
 
 // return console.log('configPath: ' + configPath)
 
-process.chdir(configPath.substring(0, configPath.lastIndexOf('/')))
+process.chdir(path.dirname(configPath))
 
 const stderr = console.error.bind( console )
 


### PR DESCRIPTION
On windows the path separator is "\\" instead of "/" so line 60 of index.js leads to 
Error: ENOENT: no such file or directory, uv_chdir
