### PR TITLE
Optional param to specify which files are watched by wrollup

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ Using a similar init process we use rollup internally to parse the rollup.config
 # Arguments
 ```bash
 -c, --config - specify path to rollup.config.js (defaults to rollup.config.js)
+--files      - specify glob of files to watch (defaults to '**/*.js*')
 --nocache    - disables bundle caching
 --verbose    - wrollup will console.log some extra info of what it is doing
 ```

--- a/index.js
+++ b/index.js
@@ -96,7 +96,7 @@ function setupGlobalWatcher () {
       }
     }
   } else {
-    verbose && console.log(cc('build error watcher still ready [**/*.js*]', c['yellow']))
+    verbose && console.log(cc('build error watcher still ready [' + allProjectFilesGlob + ']', c['yellow']))
   }
 }
 

--- a/index.js
+++ b/index.js
@@ -55,6 +55,8 @@ var colors = ['green', 'yellow', 'blue', 'cyan', 'magenta', 'white']
 
 var configPath = path.resolve(argv['c'] || argv['config'] || 'rollup.config.js')
 
+var allProjectFilesGlob = argv['files'] || '**/*.js*'
+
 // return console.log('configPath: ' + configPath)
 
 process.chdir(path.dirname(configPath))
@@ -76,11 +78,11 @@ function setupGlobalWatcher () {
       ignoreInitial: true
     }
 
-    globalWatcher = chokidar.watch('**/*.js*', opts)
+    globalWatcher = chokidar.watch(allProjectFilesGlob, opts)
     globalWatcher.on('add', triggerRebuild)
     globalWatcher.on('change', triggerRebuild)
 
-    verbose && console.log(cc('starting build error watcher [**/*.js*]', c['yellow']))
+    verbose && console.log(cc('starting build error watcher ' + allProjectFilesGlob, c['yellow']))
 
     var keys = Object.keys(watchers)
     for (let i = 0; i < keys.length; i++) {


### PR DESCRIPTION
When working on files other than *.js wrollup doesnt recover from compilation errors.
This PR introduces optional parameter "files" which allows to pass e.g.

`wrollup --verbose --files "**/*.(ts|tsx|js)"`